### PR TITLE
Delete blobs if no other tags reference (v0.0.2)

### DIFF
--- a/imagesync/img.go
+++ b/imagesync/img.go
@@ -52,3 +52,18 @@ func imageID(url string, img v1.Image) (string, error) {
 
 	return url + "@" + digest.String(), nil
 }
+
+// digestFromReference strips all content preceding the digest for the given, fully qualified, reference. If
+// no digest is present, the resulting string will be empty
+func digestFromReference(ref string) string {
+	at := strings.LastIndex(ref, "@")
+	if at == -1 {
+		return ""
+	}
+
+	if at+1 >= len(ref) {
+		return ""
+	}
+
+	return ref[at+1:]
+}


### PR DESCRIPTION
If an image being deleted is the only one that references blobs in the registry, it will now delete those blobs as well on deletion. If another image is still referencing these layers, deletion will still be limited to only the tag.

Checking the registry for other images using these layers does involve fetching the manifest for all tags, so expect long deletion times if your registry is full of many tags. If you're using this provider to simply maintain 1 or 2 versions, the on-going cleanup should mean deletion are performed in a resonable time. 

This change will comprise the v0.0.2 release.