### PR TITLE
Use Anonymous auth for all except GCR

### DIFF
--- a/imagesync/resource_imagesync.go
+++ b/imagesync/resource_imagesync.go
@@ -208,7 +208,8 @@ func authOption(ref name.Reference) (remote.Option, error) {
 	case regIP != nil && regIP.IsLoopback():
 		return remote.WithAuth(authn.Anonymous), nil
 	default:
-		return nil, fmt.Errorf("unsupported registry %s", reg.Name())
+		// return nil, fmt.Errorf("unsupported registry %s", reg.Name())
+		return remote.WithAuth(authn.Anonymous), nil
 	}
 }
 

--- a/imagesync/resource_imagesync_test.go
+++ b/imagesync/resource_imagesync_test.go
@@ -74,8 +74,8 @@ func TestImageSync(t *testing.T) {
 				Config:       stubImageSyncDockerhubConfig(destReg),
 				ResourceName: "imagesync.unit_test",
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("imagesync.unit_test", "id", destReg.URL[7:]+"/busybox@sha256:2ca5e69e244d2da7368f7088ea3ad0653c3ce7aaccd0b8823d11b0d5de956002"),
-					resource.TestCheckResourceAttr("imagesync.unit_test", "source_digest", "sha256:2ca5e69e244d2da7368f7088ea3ad0653c3ce7aaccd0b8823d11b0d5de956002"),
+					resource.TestCheckResourceAttr("imagesync.unit_test", "id", destReg.URL[7:]+"/busybox@sha256:0415f56ccc05526f2af5a7ae8654baec97d4a614f24736e8eef41a4591f08019"),
+					resource.TestCheckResourceAttr("imagesync.unit_test", "source_digest", "sha256:0415f56ccc05526f2af5a7ae8654baec97d4a614f24736e8eef41a4591f08019"),
 					resource.TestCheckResourceAttr("imagesync.unit_test", "source", "registry.hub.docker.com/library/busybox:1.32"),
 				),
 			},


### PR DESCRIPTION
I was trying to import some elastic images (ex `docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.2`) and run into `unsupported registry` error. As far as I understand, the provider supports pulling public images only so authentication should not be required? 